### PR TITLE
whitelist the help url type as well

### DIFF
--- a/src/snapd-xdg-open.c
+++ b/src/snapd-xdg-open.c
@@ -47,6 +47,7 @@ handle_method_call (GDBusConnection       *connection,
   GError *error = NULL;
 
   const gchar * const whitelist[] = {
+    "help",
     "http",
     "https",
     "mailto",


### PR DESCRIPTION
unsure why the whitelist is needed there but that simple change should let help menus in desktop software work...
