### PR TITLE
Fix ftbfs on trusty.

### DIFF
--- a/src/snapd-xdg-open.c
+++ b/src/snapd-xdg-open.c
@@ -34,6 +34,21 @@ static const gchar introspection_xml[] =
 
 static GMainLoop *loop;
 
+static gboolean
+strv_contains(const gchar * const *strv,
+              const gchar *str)
+{
+  char * const *iterator = strv;
+  while (iterator && *iterator)
+    {
+      if (g_strcmp0(*iterator, str) == 0)
+        return TRUE;
+      iterator++;
+    }
+
+  return FALSE;
+}
+
 static void
 handle_method_call (GDBusConnection       *connection,
                     const gchar           *sender,
@@ -68,7 +83,7 @@ handle_method_call (GDBusConnection       *connection,
                                                  G_DBUS_ERROR_INVALID_ARGS,
                                                  "unknown scheme: %s", url);
         }
-      else if (g_strv_contains (whitelist, scheme))
+      else if (strv_contains (whitelist, scheme))
         {
           if (g_app_info_launch_default_for_uri (url, NULL, &error))
             g_dbus_method_invocation_return_value (invocation, NULL);

--- a/src/xdg-open.c
+++ b/src/xdg-open.c
@@ -23,9 +23,10 @@ int
 main (int   argc,
       char *argv[])
 {
-  g_autoptr(GDBusConnection) bus = NULL;
-  g_autoptr(GVariant) result = NULL;
-  g_autoptr(GError) error = NULL;
+  int rc = 0;
+  GDBusConnection* bus = NULL;
+  GVariant* result = NULL;
+  GError* error = NULL;
 
   if (argc != 2)
     {
@@ -53,11 +54,19 @@ main (int   argc,
                                         NULL,
                                         &error);
 
+  g_object_unref(bus);
+
   if (result == NULL)
     {
       g_printerr ("error: %s\n", error->message);
-      return 1;
+      g_error_free(error);
+      rc = 1;
+    }
+  else
+    {
+      g_variant_unref(result);
+      rc = 0;
     }
 
-  return 0;
+  return rc;
 }


### PR DESCRIPTION
Both g_autoptr and g_strv_contains were introduced in glib 2.44.
Trusty has 2.40.0-2.