### PR TITLE
xdg-open: Fix variable cleanup

### DIFF
--- a/src/xdg-open.c
+++ b/src/xdg-open.c
@@ -65,7 +65,7 @@ main (int   argc,
 
 out:
   g_clear_object (&bus);
-  g_clear_object (&result);
+  g_variant_unref (result);
   g_clear_error (&error);
 
   return retval;

--- a/src/xdg-open.c
+++ b/src/xdg-open.c
@@ -66,7 +66,7 @@ main (int   argc,
 out:
   g_clear_object (&bus);
   g_clear_object (&result);
-  g_clear_object (&error);
+  g_clear_error (&error);
 
   return retval;
 }


### PR DESCRIPTION
This fixes the incorrect uses of `g_clear_object` on non-GObject values.