### PR TITLE
Add optional user-configurable URL scheme whitelist

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -30,5 +30,8 @@ AC_SUBST([GIO_LIBS])
 
 # checks for system services
 
+AC_ARG_ENABLE([whitelist], AS_HELP_STRING([--enable-whitelist],[enable user-configurable URL scheme whitelist]))
+AS_IF( [ test "x$enable_whitelist" = "xyes"], [AC_DEFINE([ENABLE_WHITELIST_DIR],[1], [Enable URL scheme whitelist directory])])
+
 AC_CONFIG_FILES([Makefile data/Makefile src/Makefile])
 AC_OUTPUT


### PR DESCRIPTION
Optionally allow users to expand the URL scheme whitelist from the hard-coded trio of `http`/`https`/`ftp` at their discretion, without needing to recompile the daemon.

* `configure.ac`: Introduce an autoconf `--enable-whitelist` option (disabled by default), which defines `ENABLE_WHITELIST_DIR` if present.

* `snapd-xdg-open.c`: When `ENABLE_WHITELIST_DIR` is defined, in addition to checking the whitelist, verify if `${XDG_CONFIG_HOME}/snapd-xdg-open/schemes/$scheme` exists and is a file. If so, allow opening the URL; otherwise, reject the request as before.